### PR TITLE
fix a null pointer exception raisied by permission

### DIFF
--- a/src/com/android/calendar/ImportActivity.java
+++ b/src/com/android/calendar/ImportActivity.java
@@ -183,7 +183,11 @@ public class ImportActivity extends Activity {
 
     public static boolean hasThingsToImport(Context context) {
         File folder = EventInfoFragment.EXPORT_SDCARD_DIRECTORY;
-        return folder.exists() && folder.list().length > 0;
+        if(!folder.exists()){
+            return false;
+        }
+        String[] list = folder.list();
+        return list != null && list.length > 0;
     }
 
 }


### PR DESCRIPTION
To fix that exception:

04-11 16:31:33.544: E/AndroidRuntime(9721): java.lang.NullPointerException: Attempt to get length of null array
04-11 16:31:33.544: E/AndroidRuntime(9721): 	at com.android.calendar.ImportActivity.hasThingsToImport(ImportActivity.java:186)
04-11 16:31:33.544: E/AndroidRuntime(9721): 	at com.android.calendar.AllInOneActivity.onCreateOptionsMenu(AllInOneActivity.java:790)
....

This exception will happen after flushed ROM and then click the calendar, because the default permissions of calendar doesn't include "android.permission.READ_EXTERNAL_STORAGE", after enabling the permission in app settings, it disappears.